### PR TITLE
[Context] Allow flexible Contexts to be utilized

### DIFF
--- a/cmdClient.py
+++ b/cmdClient.py
@@ -32,7 +32,7 @@ class cmdClient(discord.Client):
         self.owners = owners or []
         self.objects = {}
 
-        self.baseContext = Context  # type: Type[Context]
+        self.baseContext = baseContext  # type: Type[Context]
 
         self.ctx_cache = ctx_cache or LRUCache(1000)  # Previous Context cache, {messageid: ctxcache}
         self.active_contexts = {}  # Current active contexts, {messageid: ctx}

--- a/cmdClient.py
+++ b/cmdClient.py
@@ -26,7 +26,7 @@ class cmdClient(discord.Client):
 
     cmd_names = {}  # Command name cache, {cmdname: Command}, including aliases.
 
-    def __init__(self, prefix=None, owners=None, ctx_cache=None, baseContext=Context, **kwargs):
+    def __init__(self, prefix=None, owners=None, ctx_cache=None, baseContext: Optional[Type[Context]] = Context, **kwargs):
         super().__init__(**kwargs)
         self.prefix = prefix
         self.owners = owners or []

--- a/cmdClient.py
+++ b/cmdClient.py
@@ -26,7 +26,7 @@ class cmdClient(discord.Client):
 
     cmd_names = {}  # Command name cache, {cmdname: Command}, including aliases.
 
-    def __init__(self, prefix=None, owners=None, ctx_cache=None, baseContext: Optional[Type[Context]] = Context, **kwargs):
+    def __init__(self, prefix=None, owners=None, ctx_cache=None, baseContext: Type[Context] = Context, **kwargs):
         super().__init__(**kwargs)
         self.prefix = prefix
         self.owners = owners or []


### PR DESCRIPTION
Allow Childs of Context class to be used in cmdClient. 
This lets users of this lib to hook/override certain functions of Contexts, rendering the library more flexible.